### PR TITLE
Use goreleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -50,13 +51,11 @@ archives:
       - CREDITS
       - README.md
       - CHANGELOG.md
-    rlcp: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ .Version }}-next"
 changelog:
-  skip: true
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
I think I need to change my goreleaser configuration file to version 2
see. https://github.com/k1LoW/octocov-runn-coverage/actions/runs/11676169508/job/32511974102#step:5:11
